### PR TITLE
All the updates (confirm support for Django 3.2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: '3.9'
       - name: Python pip cache
         uses: actions/cache@v2
         with:
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: '3.9'
       - name: Python pip cache
         uses: actions/cache@v2
         with:
@@ -50,6 +50,7 @@ jobs:
           - '3.6'
           - '3.7'
           - '3.8'
+          - '3.9'
         django:
           - '2.2'
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,19 +3,19 @@ on: pull_request
 jobs:
   check:
     name: Check
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: '3.8'
       - name: Python pip cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements/testing.txt') }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements/*.txt') }}
       - name: Run check
         run: |
           pip install tox
@@ -23,19 +23,19 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: '3.8'
       - name: Python pip cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements/testing.txt') }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements/*.txt') }}
       - name: Run lint
         run: |
           pip install tox
@@ -43,7 +43,7 @@ jobs:
 
   test:
     name: Test -- Python ${{ matrix.python }} - Django ${{ matrix.django }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python:
@@ -62,14 +62,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
       - name: Python pip cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-python${{ matrix.python }}-django${{ matrix.django }}-pip-${{ hashFiles('requirements/testing.txt') }}
+          key: ${{ runner.os }}-python${{ matrix.python }}-django${{ matrix.django }}-pip-${{ hashFiles('requirements/*.txt') }}
       - name: Run tests
         env:
           PYTHON_VERSION: ${{ matrix.python }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,11 +52,7 @@ jobs:
           - '3.7'
           - '3.8'
         django:
-          - '1.11'
           - '2.2'
-        exclude:
-          - python: '3.8'
-            django: '1.11'
       fail-fast: false
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,6 @@ jobs:
     strategy:
       matrix:
         python:
-          - '3.5'
           - '3.6'
           - '3.7'
           - '3.8'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
           - '3.9'
         django:
           - '2.2'
+          - '3.2'
       fail-fast: false
     steps:
       - name: Checkout

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,9 +1,0 @@
-[isort]
-combine_as_imports = true
-sections = FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
-known_django = django
-include_trailing_comma = false
-line_length = 99
-multi_line_output = 5
-not_skip = __init__.py
-skip_glob = */migrations/*.py

--- a/Makefile
+++ b/Makefile
@@ -138,10 +138,10 @@ coverage-clean:
 
 # Black
 black-lint:
-	black --line-length 99 --target-version py35 --exclude '/migrations/' --check contentfiles tests setup.py
+	black --line-length 99 --target-version py36 --exclude '/migrations/' --check contentfiles tests setup.py
 
 black-format:
-	black --line-length 99 --target-version py35 --exclude '/migrations/' contentfiles tests setup.py
+	black --line-length 99 --target-version py36 --exclude '/migrations/' contentfiles tests setup.py
 
 
 #pipdeptree

--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ pipdeptree-check:
 
 # Project testing
 django-test:
-	PYTHONWARNINGS=all coverage run $$(which django-admin.py) test --pythonpath $$(pwd) --settings tests.settings tests
+	PYTHONWARNINGS=all coverage run $$(which django-admin) test --pythonpath $$(pwd) --settings tests.settings tests
 
 
 # Help

--- a/Makefile
+++ b/Makefile
@@ -106,10 +106,10 @@ pip-install-local: venv-check
 
 # ISort
 isort-lint:
-	isort --recursive --check-only --diff contentfiles tests
+	isort --check-only --diff contentfiles tests
 
 isort-format:
-	isort --recursive contentfiles tests
+	isort contentfiles tests
 
 
 # Flake8

--- a/Makefile
+++ b/Makefile
@@ -138,10 +138,10 @@ coverage-clean:
 
 # Black
 black-lint:
-	black --line-length 99 --target-version py36 --exclude '/migrations/' --check contentfiles tests setup.py
+	black --check contentfiles tests setup.py
 
 black-format:
-	black --line-length 99 --target-version py36 --exclude '/migrations/' contentfiles tests setup.py
+	black contentfiles tests setup.py
 
 
 #pipdeptree

--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ pipdeptree-check:
 
 # Project testing
 django-test:
-	coverage run $$(which django-admin.py) test --pythonpath $$(pwd) --settings tests.settings tests
+	PYTHONWARNINGS=all coverage run $$(which django-admin.py) test --pythonpath $$(pwd) --settings tests.settings tests
 
 
 # Help

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[tool.isort]
+combine_as_imports = true
+sections = ['FUTURE','STDLIB','DJANGO','THIRDPARTY','FIRSTPARTY','LOCALFOLDER']
+known_django = 'django'
+include_trailing_comma = true
+float_to_top = true
+force_grid_wrap = 0
+line_length = 99
+multi_line_output = 3
+skip_glob = '*/migrations/*.py'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,8 @@
+[tool.black]
+line-length = 99
+target-version = ['py36']
+exclude = '/migrations/'
+
 [tool.isort]
 combine_as_imports = true
 sections = ['FUTURE','STDLIB','DJANGO','THIRDPARTY','FIRSTPARTY','LOCALFOLDER']

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,12 +1,11 @@
 # Storages
-django-storages==1.9.1
+django-storages==1.11.1
 
 # Boto3 (and dependencies)
-boto3==1.12.48
-botocore==1.15.48
-docutils==0.15.2
-jmespath==0.9.5
+boto3==1.17.69
+botocore==1.20.69
+jmespath==0.10.0
 python-dateutil==2.8.1
-s3transfer==0.3.3
-six==1.14.0
-urllib3==1.25.9
+s3transfer==0.4.2
+six==1.16.0
+urllib3==1.26.4

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,6 +1,6 @@
 -r testing.txt
 
-bump2version==1.0.0
+bump2version==1.0.1
 Django>=2.2,<3.0
-tox==3.14.6
-twine==3.1.1
+tox==3.23.1
+twine==3.4.1

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,6 +1,6 @@
 -r testing.txt
 
 bump2version==1.0.1
-Django>=2.2,<3.0
+Django>=3.2,<4.0
 tox==3.23.1
 twine==3.4.1

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -1,6 +1,6 @@
 -r base.txt
 
-black==19.10b0 ; python_version >= '3.6'
+black==19.10b0
 coverage==5.1
 flake8==3.7.9
 isort==4.3.21

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -1,7 +1,7 @@
 -r base.txt
 
-black==19.10b0
-coverage==5.1
-flake8==3.7.9
+black==21.5b0
+coverage==5.5
+flake8==3.9.1
 isort==4.3.21
-pipdeptree==0.13.2
+pipdeptree==2.0.0

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -3,5 +3,5 @@
 black==21.5b0
 coverage==5.5
 flake8==3.9.1
-isort==4.3.21
+isort==5.8.0
 pipdeptree==2.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [bdist_wheel]
-universal = 1
+python-tag = py3

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         "Environment :: Web Environment",
         "Framework :: Django",
         "Framework :: Django :: 2.2",
+        "Framework :: Django :: 3.2",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     platforms=["any"],
     packages=find_packages(exclude=["tests"]),
     include_package_data=True,
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     install_requires=["Django>=2.2"],
     classifiers=[
         "Environment :: Web Environment",
@@ -31,7 +31,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/setup.py
+++ b/setup.py
@@ -22,11 +22,10 @@ setup(
     packages=find_packages(exclude=["tests"]),
     include_package_data=True,
     python_requires=">=3.5",
-    install_requires=["Django>=1.11"],
+    install_requires=["Django>=2.2"],
     classifiers=[
         "Environment :: Web Environment",
         "Framework :: Django",
-        "Framework :: Django :: 1.11",
         "Framework :: Django :: 2.2",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
     license="BSD",
 )

--- a/tox.ini
+++ b/tox.ini
@@ -15,8 +15,6 @@ deps =
 whitelist_externals = make
 commands = make test
 usedevelop = true
-setenv =
-    PYTHONWARNINGS = all
 
 [testenv:check]
 basepython = python3.8

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
     check
     lint
-    {py35,py36,py37,py38}-django2.2
+    {py36,py37,py38}-django2.2
     coverage
 skipsdist = true
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist =
     check
     lint
     {py36,py37,py38,py39}-django2.2
+    {py36,py37,py38,py39}-django3.2
     coverage
 skipsdist = true
 
@@ -10,6 +11,7 @@ skipsdist = true
 deps =
     -rrequirements/testing.txt
     django2.2: Django>=2.2,<3.0
+    django3.2: Django>=3.2,<4.0
 whitelist_externals = make
 commands = make test
 usedevelop = true

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 envlist =
     check
     lint
-    {py35,py36,py37}-django1.11
     {py35,py36,py37,py38}-django2.2
     coverage
 skipsdist = true
@@ -10,7 +9,6 @@ skipsdist = true
 [testenv]
 deps =
     -rrequirements/testing.txt
-    django1.11: Django>=1.11,<2.0
     django2.2: Django>=2.2,<3.0
 whitelist_externals = make
 commands = make test

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
     check
     lint
-    {py36,py37,py38}-django2.2
+    {py36,py37,py38,py39}-django2.2
     coverage
 skipsdist = true
 
@@ -15,16 +15,16 @@ commands = make test
 usedevelop = true
 
 [testenv:check]
-basepython = python3.8
+basepython = python3.9
 commands = make check
 skip_install = true
 
 [testenv:lint]
-basepython = python3.8
+basepython = python3.9
 commands = make lint
 skip_install = true
 
 [testenv:coverage]
-basepython = python3.8
+basepython = python3.9
 commands = make coverage-report
 skip_install = true


### PR DESCRIPTION
Nothing too exciting - mostly just updates which aren't changing code at all.

Newer versions of django-storages have dropped support for Django 1.11, and newer versions of boto have dropped support for Python 3.5 - so master will end up as 0.4, and we'll have a separate branch for 0.3 updates (I don't see us doing any though).