### PR TITLE
Change private_storage into a callable

### DIFF
--- a/contentfiles/storage.py
+++ b/contentfiles/storage.py
@@ -52,7 +52,7 @@ class MediaStorage(BaseContentFilesStorage):
         return f"{protocol}://{hostname}/media/{filepath_to_uri(name)}"
 
 
-class RemotePrivateStorage(BaseContentFilesStorage):
+class PrivateStorage(BaseContentFilesStorage):
     def __init__(self, *args, **kwargs):
         # Reduced expiry time to prevent URL sharing (but high enough to not expire too quickly)
         self.bucket_name = os.environ.get("CONTENTFILES_PRIVATE_BUCKET")
@@ -61,14 +61,7 @@ class RemotePrivateStorage(BaseContentFilesStorage):
         super().__init__(*args, **kwargs)
 
 
-if os.environ.get("CONTENTFILES_PRIVATE_BUCKET") is not None:
-    BasePrivateStorage = RemotePrivateStorage
-else:
-    BasePrivateStorage = DefaultStorage
-
-
-class PrivateStorage(BasePrivateStorage):
-    pass
-
-
-private_storage = PrivateStorage()
+def private_storage():
+    if os.environ.get("CONTENTFILES_PRIVATE_BUCKET") is not None:
+        return PrivateStorage()
+    return DefaultStorage()


### PR DESCRIPTION
Feels like I'm shaving a yak before I get to a PR that fixes a project, oh well.

Check: https://docs.djangoproject.com/en/3.2/ref/models/fields/#django.db.models.FileField.storage - storage being a callable has been added since Django 3.1, which means you can do `storage=private_storage` in an app that imports this - and it stores the callable function in the migration.

So, that's why everything before this has been to limit support to Django 3.2+

From a project I've tested on, creating a migration now shows this in the migration file:

```
            field=models.FileField(
                blank=True,
                storage=contentfiles.storage.private_storage,
                upload_to="private/demo/",
            ),
```