### PR TITLE
Use time-machine for testing

### DIFF
--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -3,4 +3,5 @@ check-wheel-contents==0.6.1
 coverage==7.8.0
 pipdeptree==2.26.0
 ruff==0.11.5
+time-machine==2.19.0
 twine==6.1.0

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,10 +1,11 @@
-import datetime
 import os
 from unittest import mock
 from urllib import parse
 
 from django.core.files.storage import DefaultStorage
 from django.test import TestCase, override_settings
+
+import time_machine
 
 from contentfiles.storage import MediaStorage, PrivateStorage, private_storage
 
@@ -70,12 +71,8 @@ class TestMediaStorage(TestCase):
         CONTENTFILES_S3_REGION="eu-west-2",
         CONTENTFILES_S3_ENDPOINT_URL="https://s3.dualstack.eu-west-2.amazonaws.com",
     )
-    @mock.patch("botocore.auth.datetime")
-    def test_private_storage_aws4(self, mock_datetime):
-        mock_datetime.datetime.utcnow.return_value = datetime.datetime(
-            2020, 1, 1, 12, 34, 56, 0, tzinfo=datetime.timezone.utc
-        )
-
+    @time_machine.travel("20200101T123456Z")
+    def test_private_storage_aws4(self):
         storage = PrivateStorage()
         storage.access_key = "AKIA1234567890ABCDEF"
         storage.secret_key = "1234567890123456789012345678901234567890"  # noqa:S105


### PR DESCRIPTION
Newer versions of botocore have changed the imports for datetime, and using different functions. So use time-machine as a more reliable mock.